### PR TITLE
fix(api): truncate description in AI prompt

### DIFF
--- a/apps/api/src/providers/ai/ai-utils.ts
+++ b/apps/api/src/providers/ai/ai-utils.ts
@@ -1,6 +1,7 @@
 import type { RawNewsItem, GeneratedArticle } from '../types';
 
-const MAX_CONTENT_LENGTH = 500;
+const MAX_DESCRIPTION_LENGTH = 300;
+const MAX_CONTENT_LENGTH = 400;
 
 function stripHtml(html: string): string {
   return html.replace(/<[^>]*>/g, '').replace(/\s+/g, ' ').trim();
@@ -14,10 +15,11 @@ function truncate(text: string, max: number): string {
 export function formatNewsItems(newsItems: RawNewsItem[]): string {
   return newsItems
     .map((item, index) => {
+      const cleanDescription = truncate(stripHtml(item.description), MAX_DESCRIPTION_LENGTH);
       const cleanContent = item.content
         ? truncate(stripHtml(item.content), MAX_CONTENT_LENGTH)
         : 'N/A';
-      return `${index + 1}. TÍTULO: ${item.title}\nFONTE: ${item.source}\nCATEGORIA: ${item.category}\nDATA: ${item.publishedAt.toISOString()}\nDESCRIÇÃO: ${item.description}\nCONTEÚDO: ${cleanContent}`;
+      return `${index + 1}. TÍTULO: ${item.title}\nFONTE: ${item.source}\nCATEGORIA: ${item.category}\nDATA: ${item.publishedAt.toISOString()}\nDESCRIÇÃO: ${cleanDescription}\nCONTEÚDO: ${cleanContent}`;
     })
     .join('\n\n');
 }


### PR DESCRIPTION
## Summary
- Also truncate description field (300 chars) in addition to content (400 chars)
- RSS sources like G1 have descriptions with 700+ words that still exceeded API limits

## Test plan
- [x] 144 tests passing
- [x] Re-trigger pipeline after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)